### PR TITLE
bin/compile: Source WEB_ env vars before npm ci

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -107,6 +107,19 @@ if ! command -v node &> /dev/null; then
   exit 1
 fi
 
+# Prepare WEB_ environment variables (needed for npm ci registry auth and npm run build)
+header "Preparing WEB_ environment variables"
+
+# Create a temporary file for environment variables
+ENV_FILE=$(mktemp)
+trap "rm -f $ENV_FILE" EXIT
+
+# Write all WEB_ variables to the temp file
+write_env_file "$ENV_FILE"
+
+# Source into current shell so npm ci can use them (e.g. FONTAWESOME_PACKAGE_TOKEN)
+source "$ENV_FILE"
+
 # Cache npm dependencies by package-lock.json checksum
 header "Checking for cached node_modules"
 NPM_CACHE_CHECKSUM=$(sha256sum package-lock.json | awk '{print $1}')
@@ -124,16 +137,6 @@ else
   mkdir -p "$NPM_CACHE_DIR"
   cp -R ./node_modules "$NPM_CACHE_DIR/"
 fi
-
-# Prepare WEB_ environment variables for build
-header "Preparing WEB_ environment variables for build"
-
-# Create a temporary file for environment variables
-ENV_FILE=$(mktemp)
-trap "rm -f $ENV_FILE" EXIT
-
-# Write all WEB_ variables to the temp file
-write_env_file "$ENV_FILE"
 
 # Increase Node.js memory limit for the build
 echo "export NODE_OPTIONS='--max-old-space-size=8192'" >> "$ENV_FILE"


### PR DESCRIPTION
## Summary

- Moves `write_env_file` and `source` call to before the `npm ci` block so that `WEB_`-prefixed Heroku config vars are available in the shell during dependency installation
- The build subshell is unchanged — it still sources the same env file (with `NODE_OPTIONS` appended) so `npm run build` behaviour is identical to before

## Why

We're migrating FontAwesome from a CDN kit script to the npm kit package (`@awesome.me/kit-29b4269bd1`). This package lives on FA's private npm registry and requires a token for `npm ci` to authenticate.

The token is set as `WEB_FONTAWESOME_PACKAGE_TOKEN` in Heroku config (following the existing `WEB_`-prefix convention). The buildpack strips the prefix and exports `FONTAWESOME_PACKAGE_TOKEN`, which `web/.npmrc` references via `${FONTAWESOME_PACKAGE_TOKEN}`. Without this change, the var wasn't in scope when `npm ci` ran and the install would fail with a 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)